### PR TITLE
remove 'self' module dependency

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -18,7 +18,6 @@ requires(
     "Log::Dispatch"      => 2.22,
     "Module::ExtractUse" => 0.23,
     "TAP::Harness"       => 3.16,
-    "self"               => 0.32,
     "File::ChangeNotify" => 0.12
 );
 

--- a/lib/Test/Continuous/Formatter.pm
+++ b/lib/Test/Continuous/Formatter.pm
@@ -5,14 +5,14 @@ package Test::Continuous::Formatter;
 use base 'TAP::Formatter::Base';
 use Test::Continuous::Notifier;
 use Test::Continuous::Formatter::Session;
-use self;
 
 use 5.008;
 
 our $VERSION = "0.0.2";
 
 sub open_test {
-    my ($test, $parser ) = @args;
+	my $self = shift;
+    my ($test, $parser ) = @_;
 
     my $session = Test::Continuous::Formatter::Session->new(
         {
@@ -30,7 +30,8 @@ sub open_test {
 }
 
 sub summary {
-    my ($aggregate) = @args;
+	my $self = shift;
+    my ($aggregate) = @_;
 
     my $summary;
     my $non_zero_exit_status = 0;
@@ -72,11 +73,13 @@ sub summary {
 }
 
 sub _output {
-    my $out  = join('', @args);
+	my $self = shift;
+    my $out  = join('', @_);
     $self->{__tc_output} .= "$out\n";
 }
 
 sub _analyze_test_output {
+	my $self = shift;
     my(@comment, @warning);
 
     my $output = $self->{__tc_output};

--- a/lib/Test/Continuous/Notifier.pm
+++ b/lib/Test/Continuous/Notifier.pm
@@ -4,7 +4,6 @@ use warnings;
 package Test::Continuous::Notifier;
 use Log::Dispatch;
 use Log::Dispatch::Screen;
-use self;
 
 {
     my $dispatcher;
@@ -39,7 +38,8 @@ my %status_icon = (
 );
 
 sub send_notify {
-    my ($text, $status) = args;
+	my $self = shift;
+    my ($text, $status) = @_;
     $status ||= 'info';
     if (my $notify = self->_dispatcher->remove("continuous_notify")) {
         $notify->{icon_file} = '/System/Library/CoreServices/CoreTypes.bundle/Contents/Resources/' .


### PR DESCRIPTION
Hello. gugod.
I am KHS on CPAN.

Thank you for your efforts.
Your modules are useful for me.

I am using perl5.18. 
But as you know, 'self' is not working after 5.17.6. (http://matrix.cpantesters.org/?dist=self+0.34)
So I remove dependency with self on Test::Continuous.

Whatever, I believe self is brilliant thing.

I hope that Test::Continuous goes abroad more. :-)

Have a good day
