### PR TITLE
Improve support for Test::Class based test suites

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -21,7 +21,10 @@ requires(
     "File::ChangeNotify" => 0.12
 );
 
-test_requires YAML => 0.77;
+test_requires(
+     "YAML"        => 0.77,
+     "Test::Class" => 0.41,
+);
 
 features(
     'Graphical notifications' => [

--- a/t/TestClassApp/t/lib/Bar.pm
+++ b/t/TestClassApp/t/lib/Bar.pm
@@ -1,0 +1,5 @@
+package Bar;
+use base 'Test::Class';
+use Test::More;
+sub addition : Tests { is 1 + 1, 2, '1 + 1 is 2' }
+1;

--- a/t/TestClassApp/t/lib/Foo.pm
+++ b/t/TestClassApp/t/lib/Foo.pm
@@ -1,0 +1,5 @@
+package Foo;
+use base 'Test::Class';
+use Test::More;
+sub concatination : Tests { is 'foo' . 'bar', 'foobar', '"foo" . "bar" is "foobar"' }
+1;

--- a/t/TestClassApp/t/runtests.t
+++ b/t/TestClassApp/t/runtests.t
@@ -1,0 +1,2 @@
+use Test::Class::Load 't/lib';
+Test::Class->runtests(@ARGV);

--- a/t/testclassapp-argv-contains-foo-and-bar.t
+++ b/t/testclassapp-argv-contains-foo-and-bar.t
@@ -1,0 +1,24 @@
+#!/usr/bin/env perl -w
+use strict;
+use lib 't';
+use Test::More tests => 3;
+require 'mock.pl';
+
+use Test::Continuous;
+use Test::Continuous::Notifier;
+
+use Cwd 'chdir';
+
+chdir('t/TestClassApp');
+
+{
+    local @ARGV = qw(t/runtests.t :: Bar Foo);
+
+    Test::Continuous::_run_once;
+
+    my @notifications = read_notifications();
+
+    like $notifications[0], qr/ALL PASSED/,          'tests pass';
+    like $notifications[1], qr/Bar\->addition/,      'Bar tests run';
+    like $notifications[1], qr/Foo\->concatination/, 'Foo tests run';
+}

--- a/t/testclassapp-argv-contains-nothing.t
+++ b/t/testclassapp-argv-contains-nothing.t
@@ -1,0 +1,24 @@
+#!/usr/bin/env perl -w
+use strict;
+use lib 't';
+use Test::More tests => 3;
+require 'mock.pl';
+
+use Test::Continuous;
+use Test::Continuous::Notifier;
+
+use Cwd 'chdir';
+
+chdir('t/TestClassApp');
+
+{
+    local @ARGV = qw();
+
+    Test::Continuous::_run_once;
+
+    my @notifications = read_notifications();
+
+    like $notifications[0], qr/ALL PASSED/,          'tests pass';
+    like $notifications[1], qr/Bar\->addition/,      'Bar tests run';
+    like $notifications[1], qr/Foo\->concatination/, 'Foo tests run';
+}

--- a/t/testclassapp-argv-contains-only-bar.t
+++ b/t/testclassapp-argv-contains-only-bar.t
@@ -1,0 +1,24 @@
+#!/usr/bin/env perl -w
+use strict;
+use lib 't';
+use Test::More tests => 3;
+require 'mock.pl';
+
+use Test::Continuous;
+use Test::Continuous::Notifier;
+
+use Cwd 'chdir';
+
+chdir('t/TestClassApp');
+
+{
+    local @ARGV = qw(t/runtests.t :: Bar);
+
+    Test::Continuous::_run_once;
+
+    my @notifications = read_notifications();
+
+    like   $notifications[0], qr/ALL PASSED/,          'tests pass';
+    like   $notifications[1], qr/Bar\->addition/,      'Bar tests run';
+    unlike $notifications[1], qr/Foo\->concatination/, 'Foo tests run';
+}

--- a/t/testclassapp-argv-contains-only-foo.t
+++ b/t/testclassapp-argv-contains-only-foo.t
@@ -1,0 +1,24 @@
+#!/usr/bin/env perl -w
+use strict;
+use lib 't';
+use Test::More tests => 3;
+require 'mock.pl';
+
+use Test::Continuous;
+use Test::Continuous::Notifier;
+
+use Cwd 'chdir';
+
+chdir('t/TestClassApp');
+
+{
+    local @ARGV = qw(t/runtests.t :: Foo);
+
+    Test::Continuous::_run_once;
+
+    my @notifications = read_notifications();
+
+    like   $notifications[0], qr/ALL PASSED/,          'tests pass';
+    unlike $notifications[1], qr/Bar\->addition/,      'Bar tests run';
+    like   $notifications[1], qr/Foo\->concatination/, 'Foo tests run';
+}


### PR DESCRIPTION
Quite often *(if you have a huge, slow test suite)* it can be useful to only run a subset of your tests defined using [Test::Class](https://metacpan.org/pod/Test::Class):
```
autoprove -flmv t/runtests.t :: Foo
```
Due to the way `@ARGV` is currently processed, this will produce the following output:
```
prove --norc -flmv t/runtests.t :: Foo /vagrant/t/TestClassApp/t/runtests.t
1 planned, only 1 passed.
 Non-zero exit status: t/runtests.t
t/runtests.t:
/vagrant/t/TestClassApp/t/runtests.t is not Test::Class or integer at t/runtests.t line 2.
All 1 subtests passed t/runtests.t:
# 
# Foo->concatination
# Looks like your test exited with 255 just after 1.
```
This change cleans up the processing of `@ARGV` to generate a `prove` command that gets run without throwing the warnings:
```
prove --norc -flmv t/runtests.t :: Foo
ALL PASSED
t/runtests.t:
# 
# Foo->concatination
```
Do let me know if this is of any use.