### PR TITLE
_classify_argv tests for directories as well as files

### DIFF
--- a/lib/Test/Continuous.pm
+++ b/lib/Test/Continuous.pm
@@ -24,8 +24,8 @@ my @classes;
 
 sub _classify_argv {
     if (@ARGV) {
-        @not_files  = grep   { !-f $_ }     @ARGV;
-        @tests      = grep   {  -f $_ }     @ARGV;
+        @not_files  = grep   { !( -f $_ or -d $_ ) }     @ARGV;
+        @tests      = grep   {    -f $_ or -d $_   }     @ARGV;
         @classes    = after  { $_ eq '::' } @not_files;
         @prove_args = before { $_ eq '::' } @not_files;
     }

--- a/t/SimpleApp/include/include-me.t
+++ b/t/SimpleApp/include/include-me.t
@@ -1,0 +1,7 @@
+#!/usr/bin/env perl -w
+use strict;
+use Test::More tests => 1;
+
+diag 'Yay! I feel included! \(^.^)/';
+
+pass;

--- a/t/simpleapp-files-arg.t
+++ b/t/simpleapp-files-arg.t
@@ -1,0 +1,26 @@
+#!/usr/bin/env perl -w
+use strict;
+use lib 't';
+require 'mock.pl';
+
+use Test::More tests => 1;
+use Test::Continuous;
+
+use Cwd qw(chdir);
+
+require 'mock.pl';
+
+
+@ARGV = ( 't/simple.t', 'include' );
+
+chdir("t/SimpleApp");
+
+Test::Continuous::_run_once;
+
+my @notified = read_notifications();
+
+is_deeply(
+    \@notified,
+    [ "ALL PASSED\n", 'include/include-me.t:
+# Yay! I feel included! \(^.^)/' ]
+, 'directories and files can be passed as file arguments');


### PR DESCRIPTION
Since only the `-f` test was run, directories couldn't be passed as files
to test and instead were included as prove args.

Added a test file to `t/SimpleApp/include` with a `diag()` call to ensure the directory was included. The `diag()` is then tested in the output.