### PR TITLE
Allow temp directory created in test to be able to be cleaned up.

### DIFF
--- a/t/01.exclude-list.t
+++ b/t/01.exclude-list.t
@@ -178,3 +178,5 @@ META.*';
         $gitignore_repo.'/test.swp',
    ], 'default exclude list returned in environment with files';
 };
+
+chdir $home; # so we can clean up the temp files


### PR DESCRIPTION
This is a very trivial change - I suspect you meant to do this, since you saved the starting location before the chdir (into $home).  The temp directory couldn't be removed because the test chdir()-ed into the temp directory.

It avoids this warning message during make test:
t/01.exclude-list.t ......................... 1/3 cannot remove path when cwd is /tmp/vUtktuDjJl/ignorewfiles for /tmp/vUtktuDjJl:  at /usr/share/perl/5.20/File/Temp.pm line 778.

That message didn't impact whether or not tests passed, but it still is good to clean up that directory.

FYI - I got your module in the CPAN Pull Request Challenge, and will likely be doing some more pull requests, but I thought it probably best to separate the changes in case you like some but not others, hence this extremely trivial pull request.  I'm focusing primarily on test failures seen by cpantesters.