### PR TITLE
Use perl that Test::Continuous uses to run prove, even if not in path

### DIFF
--- a/lib/Test/Continuous.pm
+++ b/lib/Test/Continuous.pm
@@ -148,7 +148,27 @@ sub _run_once {
 
     print "\033[2J\033[0;0H"; #cls
     print "prove --norc " . join(" ", @command_args) . "\n";
-    system(qw(prove --norc -v -m --formatter Test::Continuous::Formatter), @command_args);
+
+    # This is from the prove source code
+    my $script = <<'EOS';
+        use strict;
+        use warnings;
+        use App::Prove;
+
+        my $app = App::Prove->new();
+        $app->process_args(@ARGV);
+        exit( $app->run ? 0: 1 );
+EOS
+
+    # We don't run "prove" directly because the prove in the system path
+    # may be very different than the perl that this module is running
+    # under.  So we "simulate" prove by using App::Prove (using the data
+    # in $script from above).
+    system(
+        $^X, '-e', $script,
+        qw(-- --norc -v -m --formatter Test::Continuous::Formatter),
+        @command_args
+    );
 }
 
 sub _rebuild {


### PR DESCRIPTION
Instead of relying on the path to find 'prove', this uses $^X. This is more compatible with multiple installations of Perl, as it will assume that you want to test the application under whatever version of
Perl is running Test::Continuous, rather than what is in the system path. As a nice side-effect of this, cpantesters that have multiple perl versions installed will not report test failures for this reason (that is the reason for the vast majority of test failures being reported right now).  I validated this passes tests on Solaris, Windows (for versions of Cygwin that allow pre-requisite modules to install), and Linux x64 and ARMv7.

The use of $^X and building a script that does what prove does (call App::Prove with the appropriate arguments) rather than to try to find prove in the path is to try to allow this to work on systems that don't necessarily have Unix-like paths, or where prove is installed in a different location than Perl.