### PR TITLE
Allow skipping of initial tests with an environmental variable

### DIFF
--- a/README
+++ b/README
@@ -37,10 +37,17 @@ INTERFACE
         this distribution to do this instead.
 
 CONFIGURATION AND ENVIRONMENT
-    Test::Continuous requires no configuration files or environment
-    variables.
+    Test::Continuous requires no configuration files.
 
-    Your ".proverc" is NOT loaded, even though it's based on App::Prove.
+    Your C<.proverc> is NOT loaded, even though it's based on App::Prove.  
+
+    One environmental variable is parsed, C<TEST_CONTINUOUS>.  This variable
+    can only have one value, C<SKIP_INITIAL>, which signals to this module
+    that you do not want the module to run all test files when the program
+    starts.  Generally, you should run all tests, in case something changed
+    while C<Test::Continuous> was not running, but this functionality may
+    be useful in some circumstances.  If C<TEST_CONTINUOUS> is not set, the
+    standard initial tests are run (this is recommended).
 
 DEPENDENCIES
     App::Prove, Log::Dispatch, Log::Dispatch::DesktopNotification,

--- a/bin/autoprove
+++ b/bin/autoprove
@@ -49,6 +49,20 @@ is modified.
 
 If a C<.t> file is modified, only that test file will be run.
 
+=head1 CONFIGURATION AND ENVIRONMENT
+
+Test::Continuous requires no configuration files.
+
+Your C<.proverc> is NOT loaded, even though it's based on L<App::Prove>.
+
+One environmental variable is parsed, C<TEST_CONTINUOUS>.  This variable
+can only have one value, C<SKIP_INITIAL>, which signals to this module
+that you do not want the module to run all test files when the program
+starts.  Generally, you should run all tests, in case something changed
+while C<Test::Continuous> was not running, but this functionality may
+be useful in some circumstances.  If C<TEST_CONTINUOUS> is not set,
+the standard initial tests are run (this is recommended).
+
 =head1 AUTHOR
 
 Kang-min Liu C<< <gugod@gugod.org> >>

--- a/cpanfile
+++ b/cpanfile
@@ -11,8 +11,9 @@ requires "Git::Repository"    => 0;
 requires "Test::More"         => 0.42;
 
 on test => sub {
-    requires "YAML"        => 0.77;
-    requires "Test::Class" => 0.50;
+    requires "YAML"            => 0.77;
+    requires "Test::Class"     => 0.50;
+    requires "Test::Exception" => 0.40;
 };
 
 feature 'notify', 'Graphical notifications' => sub {

--- a/t/TestClassApp/t/runtests.t
+++ b/t/TestClassApp/t/runtests.t
@@ -1,2 +1,3 @@
 use Test::Class::Load 't/lib';
+undef($ENV{TEST_CONTINUOUS}); # In case it's set.
 Test::Class->runtests(@ARGV);

--- a/t/env_variable.t
+++ b/t/env_variable.t
@@ -1,0 +1,88 @@
+#!/usr/bin/env perl -w
+use strict;
+use lib 't';
+require 'mock.pl';
+
+use Test::More tests => 7;
+use Test::Exception;
+use Test::Continuous;
+
+use Cwd qw(chdir);
+
+package null_wait_for_events;
+# This package defines a replacement used in place for
+# File::ChangeNotify that always returns undef on wait_for_events(), so
+# that the tests done on changes are never done in
+# Test::Continuous::runtests() (we don't want to loop forever there).
+sub new {
+    my $class = {};
+    bless($class);
+    return $class;
+}
+sub wait_for_events {
+    return (); # So this exits runtests()
+}
+
+
+package main;
+
+my $count = 0;  # Stores how many times _run_once runs
+
+{
+    no warnings 'redefine';  # We're redefining functions
+    
+    # We change the constructor to point at our null class
+    sub File::ChangeNotify::instantiate_watcher { return null_wait_for_events->new(); }
+
+    # We don't actually do any tests anymore, but we keep count of how
+    # many times this is called.
+    sub Test::Continuous::_run_once { $count++; }
+};
+
+
+chdir("t/SimpleApp");
+
+$ENV{TEST_CONTINUOUS} = 'SKIP_INITIAL,BOGUS';
+throws_ok {Test::Continuous::runtests()} qr/Unknown option/,
+    'Good + Bad TEST_CONTINUOUS Option dies';
+
+$ENV{TEST_CONTINUOUS} = 'SKIP_INITIAL_BOGUS';
+throws_ok {Test::Continuous::runtests()} qr/Unknown option/,
+    'Bad TEST_CONTINUOUS option dies';
+
+undef($ENV{TEST_CONTINUOUS});
+lives_ok {Test::Continuous::runtests()} 'Undef TEST_CONTINUOUS works';
+
+$ENV{TEST_CONTINUOUS} = 'SKIP_INITIAL';
+lives_ok {Test::Continuous::runtests()} 'SKIP_INITIAL TEST_CONTINUOUS works';
+
+# Case insensitivity test
+$ENV{TEST_CONTINUOUS} = 'skip_initial';
+lives_ok {Test::Continuous::runtests()} 'skip_initial TEST_CONTINUOUS works';
+
+undef($ENV{TEST_CONTINUOUS}); # Make sure this isn't set to anything
+$count=0; # reset count of how many times _run_once() is called
+
+Test::Continuous::runtests();
+
+# We should call _run_once() for the initial tests when runtests()
+# starts.
+is(
+    $count,
+    1,
+    '_run_once() properly called once when not skipping initial tests'
+);
+
+
+$ENV{TEST_CONTINUOUS} = 'SKIP_INITIAL';
+$count = 0;  # Stores how many times _run_once runs
+
+Test::Continuous::runtests();
+
+# We should NOT call _run_once() for the initial tests when runtests()
+# starts, and we exit before we call it for changes.
+is(
+    $count,
+    0,
+    '_run_once() not called for initial tests when skipping initial tests'
+);


### PR DESCRIPTION
First, I'm not sure this is the perfect way to do this, so absolutely use your judgement on whether or not this is the way you want to do it - if it isn't, I'm glad to rework this if you would like a different method of doing something like this.  This is one implementation to provide the feature asked for in https://rt.cpan.org/Ticket/Display.html?id=84153 - "I have a project that has a lot of tests, and I'd like to only run the tests as I change code, not a big initial run[.] Could I add a "--watch_only" or some other flag to autoprove that would skip the initial _run_once() call? Would that be an acceptable solution to my problem?"

I thought that the command line already had a lot of stuff on it, so I chose an environmental variable.  I structured it so that you could add additional options at a later time, by simply allowing the options in the TEST_CONTINUOUS environmental variable to be separated by commas.  The only option defined right now is "SKIP_INITIAL".  I also changed documentation to reflect how this works, with a strong suggestion to not do this (since it probably generally shouldn't be done), but there are likely valid uses in really large systems, or in systems where tests take a very long time to run.

I also added a set of new tests in env_variable.t, which try the various combinations of valid and invalid environmental variables, and validate that they do what they should.  These tests use Test::Exception, which seems to support all versions of Perl that Test::Continuous does - I added Test::Exception to the tests section of cpanfile (you may want to move Test::More to there; you may also want to add a devel section to cpanfile with Module::Build::AuthorTests and Module::Build::CPANfile listed, since these are required to build the module from the Git repo).

I didn't update the change log, as I don't know if other changes would go out with this, should you agree with this pull request.