### PR TITLE
Make screen clearing somewhat more portable

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -9,6 +9,7 @@ requires "TAP::Harness"       => 3.16;
 requires "File::ChangeNotify" => 0.12;
 requires "Git::Repository"    => 0;
 requires "Test::More"         => 0.42;
+requires "Term::Cap"          => 1.10;
 
 on test => sub {
     requires "YAML"        => 0.77;

--- a/lib/Test/Continuous.pm
+++ b/lib/Test/Continuous.pm
@@ -15,7 +15,9 @@ use Test::Continuous::Formatter;
 use File::ChangeNotify;
 use Git::Repository;
 use YAML;
+use Term::Cap;
 
+my $cls;
 my @prove_args;
 my @tests;
 my @changes;
@@ -146,7 +148,7 @@ sub _run_once {
     my @tests = _tests_to_run;
     my @command_args = ( @prove_args, @tests, '::', @classes );
 
-    print "\033[2J\033[0;0H"; #cls
+    _cls();
     print "prove --norc " . join(" ", @command_args) . "\n";
     system(qw(prove --norc -v -m --formatter Test::Continuous::Formatter), @command_args);
 }
@@ -214,6 +216,35 @@ sub runtests {
            sleep 3;
         }
     }
+}
+
+sub _cls {
+
+    # Cache clear screen
+    if (!defined($cls)) {
+        if ( -t STDOUT ) {
+            # We are on a terminal
+            
+            my $term = Term::Cap->Tgetent({OSPEED=>9600});
+            $cls = $term->Tputs('cl');
+
+            if ($cls eq '') {
+                # It's a stupid terminal.
+                # We set this to null so it'll get a sensible default
+                # later.
+                $cls = undef;
+            }
+        }
+
+        # We're either not using a terminal or we're using a really
+        # stupid terminal.
+        if (!defined($cls)) {
+            # Not on a terminal, just skip a couple lines
+            $cls = "\n\n";
+        }
+    }
+
+    print $cls;
 }
 
 1;


### PR DESCRIPTION
This may not merge perfectly with some of my other pull requests I've put in today - but it should be easy to resolve any conflicts.  If you do like this change, and you like another of my change that conflicts, feel free to make me do a new pull request after you merge the other changes that you like.

Printing ANSI escape sequences to clear the screen breaks several things - Strawberry Perl on Win32, non-standard terminals, dumb terminals, and pipes/redirection of the output.  I made the clear screen call a function - _cls() - and use Term::Cap (a core module) to get the clear code.  If the program is not connected to a terminal (redirected output, for instance), if the terminal isn't known to Term::Cap, or if the terminal is particularly dumb (TERM=dumb), two newlines are printed instead.

I do cache the clear screen code, which probably isn't necessary, but it's a little nicer as far as performance.

This is the last pull request I'm submitting based on the things I saw in the module that I thought I could help with - feel free to give me feedback if you like these ideas but would like to do them a different way, I definitely want this work to fit into your desires for the module.