### PR TITLE
Don't crash when run on a directory that isn't a git directory

### DIFF
--- a/lib/Test/Continuous.pm
+++ b/lib/Test/Continuous.pm
@@ -103,9 +103,12 @@ sub _get_exclude_list {
 
     # Attempt to get the git directory Test::Continuous was run in
     my $path = getcwd;
-    my $git_repo_top_level = Git::Repository->run( 'rev-parse', '--show-toplevel', {
-        cwd => $path,
-    });
+    my $git_repo_top_level;
+    eval {
+        $git_repo_top_level = Git::Repository->run( 'rev-parse', '--show-toplevel', {
+            cwd => $path,
+        });
+    };
     my ( $git_ignore, $git_dir );
 
     # If the git command came up with a git repo use it's .gitignore
@@ -150,7 +153,7 @@ sub _run_once {
     my @command_args = ( @prove_args, @tests, '::', @classes );
 
     _cls();
-    print "prove --norc " . join(" ", @command_args) . "\n";
+    print "prove --norc -v -m " . join(" ", @command_args) . "\n";
 
     # This is from the prove source code
     my $script = <<'EOS';


### PR DESCRIPTION
When Test::Continuous is run on a directory that is not a git directory, it crashes with a fatal error.  I wrapped the call to Git::Repository in an eval {} block, so that if Git::Repository decides to die() (because it's not a git directory), it won't stop the program from continuing.