### PR TITLE
Override "/.gitignore" from the core.excludesfile

### DIFF
--- a/t/01.exclude-list.t
+++ b/t/01.exclude-list.t
@@ -74,7 +74,7 @@ subtest 'git repo w/ .gitignore and w/o files' => sub {
    isa_ok $r, 'Git::Repository';
    my $gitignore_handle;
    open ($gitignore_handle, '>', $gitignore_repo.'/.gitignore') or die('Unable to open '.$gitignore_repo.'/.gitignore');
-   print $gitignore_handle "*.swp";
+   print $gitignore_handle join "\n", '*.swp', '!/.gitignore';
    close ($gitignore_handle) or die ("Unable to close ".$gitignore_repo.'/.gitignore');
 
    # Go there
@@ -126,8 +126,7 @@ subtest 'git repo w/ .gitignore and w/ files' => sub {
    isa_ok $r, 'Git::Repository';
    my $gitignore_handle;
    open ($gitignore_handle, '>', $gitignore_repo.'/.gitignore') or die('Unable to open '.$gitignore_repo.'/.gitignore');
-   print $gitignore_handle '*.swp
-META.*';
+   print $gitignore_handle join "\n", '*.swp', 'META.*', '!/.gitignore';
    close ($gitignore_handle) or die ("Unable to close ".$gitignore_repo.'/.gitignore');
 
    # Touch some files to be included in the exclude list

--- a/t/mock.pl
+++ b/t/mock.pl
@@ -2,7 +2,7 @@ use FindBin;
 use File::Temp;
 use YAML;
 
-$ENV{PERL5LIB} = join(":", $FindBin::Bin."/lib", $FindBin::Bin."/../lib", $ENV{PERL5LIB});
+$ENV{PERL5LIB} = join(":", $FindBin::Bin."/lib", $FindBin::Bin."/../lib", $ENV{PERL5LIB} || "");
 
 my $temp = File::Temp->new;
 $temp->unlink_on_destroy(0);


### PR DESCRIPTION
Many developers exclude the `.gitignore` files from multiple projects and as such have excluded it in their [core.excludesFile](https://git-scm.com/docs/gitignore). Noticed failing tests as follows:
```
t/00.load.t ................................. 1/1 # Testing Test::Continuous 0.76
t/00.load.t ................................. ok
t/01.exclude-list.t ......................... 1/3     
    #   Failed test 'default exclude list returned in environment with no files'
    #   at t/01.exclude-list.t line 83.
    #     Structures begin differing at:
    #          $got->[8] = '/tmp/DpH392Evg5/gitignore/.gitignore'
    #     $expected->[8] = Does not exist
    # Looks like you failed 1 test of 3.

#   Failed test 'git repo w/ .gitignore and w/o files'
#   at t/01.exclude-list.t line 115.
    
    #   Failed test 'default exclude list returned in environment with files'
    #   at t/01.exclude-list.t line 145.
    #     Structures begin differing at:
    #          $got->[8] = '/tmp/DpH392Evg5/ignorewfiles/.gitignore'
    #     $expected->[8] = '/tmp/DpH392Evg5/ignorewfiles/META.json'
    # Looks like you failed 1 test of 3.

#   Failed test 'git repo w/ .gitignore and w/ files'
#   at t/01.exclude-list.t line 180.
# Looks like you failed 2 tests of 3.
t/01.exclude-list.t ......................... Dubious, test returned 2 (wstat 512, 0x200)
Failed 2/3 subtests 
t/options.t ................................. Use of uninitialized value in join or string at t/mock.pl line 5.
t/options.t ................................. ok
t/simpleapp-diag.t .......................... Use of uninitialized value in join or string at t/mock.pl line 5.
t/simpleapp-diag.t .......................... ok
t/simpleapp-dubious.t ....................... Use of uninitialized value in join or string at t/mock.pl line 5.
t/simpleapp-dubious.t ....................... ok
t/simpleapp-files-arg.t ..................... Use of uninitialized value in join or string at t/mock.pl line 5.
t/simpleapp-files-arg.t ..................... ok
t/simpleapp-simple.t ........................ Use of uninitialized value in join or string at t/mock.pl line 5.
t/simpleapp-simple.t ........................ ok
t/testclassapp-argv-contains-foo-and-bar.t .. Use of uninitialized value in join or string at t/mock.pl line 5.
t/testclassapp-argv-contains-foo-and-bar.t .. ok
t/testclassapp-argv-contains-nothing.t ...... Use of uninitialized value in join or string at t/mock.pl line 5.
t/testclassapp-argv-contains-nothing.t ...... ok
t/testclassapp-argv-contains-only-bar.t ..... Use of uninitialized value in join or string at t/mock.pl line 5.
t/testclassapp-argv-contains-only-bar.t ..... ok
t/testclassapp-argv-contains-only-foo.t ..... Use of uninitialized value in join or string at t/mock.pl line 5.
t/testclassapp-argv-contains-only-foo.t ..... ok

Test Summary Report
-------------------
t/01.exclude-list.t                       (Wstat: 512 Tests: 3 Failed: 2)
  Failed tests:  2-3
  Non-zero exit status: 2
Files=11, Tests=37,  6 wallclock secs ( 0.07 usr  0.00 sys +  5.54 cusr  0.39 csys =  6.00 CPU)
Result: FAIL
```
This patch provides 2 fixes:
+ overrides `/.gitignore` in the `core.excludesFile`
+ eliminate `uninitialised value` warning