### PR TITLE
Update contributor's name

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,8 +1,8 @@
 Revision history for Test-Continuous
 
 0.76:
-- Fix the crash when running under a non-git dir. (Joel Maslak)++
-- Add "--autoprove-skip-initial" CLI arg to skip the initial test (Joel Maslak)++
+- Fix the crash when running under a non-git dir. (Joelle Maslak)++
+- Add "--autoprove-skip-initial" CLI arg to skip the initial test (Joelle Maslak)++
 - Fix: `autoprove <dir>` now works as it is supposed to be. (Sean Zellmer)++
 
 0.75:


### PR DESCRIPTION
I've recently change my name - and while I understand it is somewhat unusual to modify history (like the Changes file), I'd love to see the next release of Test::Continuous reflect my identity.